### PR TITLE
[SPE-474] Update Activesupport

### DIFF
--- a/lib/xirr/version.rb
+++ b/lib/xirr/version.rb
@@ -1,4 +1,4 @@
 module Xirr
   # Version of the Gem
-  VERSION = '0.9.2'
+  VERSION = '0.10.0'
 end

--- a/xirr.gemspec
+++ b/xirr.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>=2.2.2'
 
-  spec.add_dependency 'activesupport', '~> 6.1'
+  spec.add_dependency 'activesupport', '>= 6.1'
 
   spec.add_development_dependency 'minitest', '~> 5.11'
   spec.add_development_dependency 'coveralls', '~> 0.8'


### PR DESCRIPTION
https://smartpension.atlassian.net/browse/SPE-474

---

Our activesupport dependency is locked to a version below 7. In order for us to have a smooth transition to rails 7, we need to ensure our gem requires activesupport greater than 7